### PR TITLE
Honor nrepl log options

### DIFF
--- a/perl/Makefile
+++ b/perl/Makefile
@@ -59,7 +59,7 @@ clean:
 
 #------------------------------------------------------------------------------
 nrepl: nrepl-kill
-	lingy --nrepl --nrepl-logging --verbose & echo $$! > $(NREPL_PID_FILE)
+	LINGY_NREPL_LOG_FILE=1 lingy --nrepl & echo $$! > $(NREPL_PID_FILE)
 	@echo "*** lingy nREPL Running... (pid $$(< $(NREPL_PID_FILE)))"
 	@echo
 	@sleep 0.5

--- a/perl/bin/lingy
+++ b/perl/bin/lingy
@@ -22,10 +22,6 @@ Options:
   -e, --eval      Eval a Lingy source string; print non-nil
   --repl          Start Lingy REPL (default w/ no args)
   --run           Run a Lingy program (default w/ file name)
-  --nrepl         Start an nREPL server
-  --nrepl-logging [<file>]
-                  Log nREPL messages to <file> (default: ./.nrepl.log, use - for stdout)
-  --verbose       Verbose logging
 
   -D, --dev       Load the lingy.devel library
   -C, --clj       Enable Clojure mode in REPL
@@ -33,7 +29,9 @@ Options:
   --ppp           Compile file and print AST (Lingy)
   --xxx           Compile file and dump internal AST (YAML)
 
+  --nrepl         Start an nREPL server
   --execs         List executables for setting LINGY_EXEC
+
   --version       Print version
   -h, --help      Print help and exit
 "

--- a/perl/bin/lingy
+++ b/perl/bin/lingy
@@ -22,6 +22,10 @@ Options:
   -e, --eval      Eval a Lingy source string; print non-nil
   --repl          Start Lingy REPL (default w/ no args)
   --run           Run a Lingy program (default w/ file name)
+  --nrepl         Start an nREPL server
+  --nrepl-logging [<file>]
+                  Log nREPL messages to <file> (default: ./.nrepl.log, use - for stdout)
+  --verbose       Verbose logging
 
   -D, --dev       Load the lingy.devel library
   -C, --clj       Enable Clojure mode in REPL

--- a/perl/lib/Lingy/Main.pm
+++ b/perl/lib/Lingy/Main.pm
@@ -17,7 +17,6 @@ use constant options => +{
     run         => 'arg',
     version     => 'bool',
     xxx         => 'bool',
-    'verbose'   => 'bool',
 };
 
 
@@ -83,11 +82,7 @@ sub do_eval {
 sub do_nrepl {
     my ($self) = @_;
     require Lingy::nREPL;
-    my $nrepl = Lingy::nREPL->new(
-        logging => $self->{'nrepl-logging'},
-        verbose => $self->{'verbose'},
-    );
-    $nrepl->start->run;
+    Lingy::nREPL->new->start->run;
 }
 
 sub do_repl {
@@ -140,8 +135,6 @@ sub getopt {
         print $ENV{LINGY_USAGE};
         exit 0;
     };
-
-    $spec->{'nrepl-logging:s'} = \$self->{'nrepl-logging'};
 
     Getopt::Long::Configure(qw(
         gnu_getopt

--- a/perl/lib/Lingy/Main.pm
+++ b/perl/lib/Lingy/Main.pm
@@ -12,7 +12,6 @@ use constant options => +{
     'dev|D'     => 'bool',
     'eval|e'    => 'str',
     nrepl       => 'bool',
-    'nrepl-logging' => 'bool',
     ppp         => 'bool',
     repl        => 'bool',
     run         => 'arg',
@@ -26,7 +25,7 @@ sub new {
     my $class = shift;
 
     bless {
-        map( ($_, ''), keys %{$class->options} ),
+        map( ($_, undef), keys %{$class->options} ),
         @_,
     }, $class;
 }
@@ -142,6 +141,8 @@ sub getopt {
         exit 0;
     };
 
+    $spec->{'nrepl-logging:s'} = \$self->{'nrepl-logging'};
+
     Getopt::Long::Configure(qw(
         gnu_getopt
         no_auto_abbrev
@@ -161,7 +162,6 @@ sub getopt {
             $self->{run} = '/dev/stdin'
                 if $self->{run} eq '-';
         }
-
     } else {
         if ($self->from_stdin) {
             $self->{run} = '/dev/stdin';

--- a/perl/lib/Lingy/nREPL.pm
+++ b/perl/lib/Lingy/nREPL.pm
@@ -156,7 +156,7 @@ sub run {
     my $client = 0;
 
     while (1) {
-        my @ready = $select->can_read;
+        my @ready = $select->can_read(0);
         foreach my $socket (@ready) {
             delete @{$self}{qw( conn request )};
 
@@ -200,6 +200,7 @@ sub run {
                 });
             }
         }
+        sleep 0.01;
     }
 }
 

--- a/perl/lib/Lingy/nREPL.pm
+++ b/perl/lib/Lingy/nREPL.pm
@@ -126,7 +126,7 @@ sub start {
 
     io(port_file)->print($port);
 
-    print "Starting: nrepl://127.0.0.1:$port\n";
+    print "nREPL server started on port $port on host 127.0.0.1 - nrepl://127.0.0.1:$port\n";
     if (defined($self->{logging})) {
         print "Log file: $self->{log}\n" unless $self->{logging} eq '-';
     }


### PR DESCRIPTION
We were logging regardless if the `nrepl-logging` was specified or not. Now fixed.

I also made it possible to specify a custom log file, mainly in order to support the custom log file named `-` for `stdout`. So now I can start the server like so:

```sh
$  lingy --nrepl --nrepl-logging - --verbose
nREPL server started on port 41078 on host 127.0.0.1 - nrepl://127.0.0.1:41078
===: START
url: nrepl://127.0.0.1:41078

^C===: INTERUPT

===: STOP
url: nrepl://127.0.0.1:41078
```

And, as shown, interrupt will work as expected. Also shown is that I changed the starting message to be the standard used by ost nREPL servers and expected by most nREPL clients (Calva included).

There's also a change in using `can_read(0)` for polling the socket. Freeing the socket so that we can write to it without first having read a message.