### PR TITLE
nrepl stdout

### DIFF
--- a/perl/lib/Lingy/nREPL.pm
+++ b/perl/lib/Lingy/nREPL.pm
@@ -96,19 +96,16 @@ sub op_eval {
     eval {
         if (my @results = $self->{repl}->reps($code)) {
             $result = $results[-1];
-            $self->send_response( { value => $result } );
+            $self->send_response({
+                value => $result,
+                ns => RT->current_ns_name
+            });
         }
         1;
     } or do {
         my $error = $@;
         $self->send_response( { err => $error } );
     };
-    $result = $@ if $@;
-
-    $self->send_response({
-        value => $result,
-        ns => RT->current_ns_name
-    });
 
     $self->send_response( { status => 'done' } );
 }

--- a/perl/lib/Lingy/nREPL.pm
+++ b/perl/lib/Lingy/nREPL.pm
@@ -94,10 +94,11 @@ sub op_eval {
 
     my $result;
     eval {
-        my @results = $self->{repl}->reps($code);
-        $result = $results[-1];
-        $self->send_response( { value => $result } );
-        1
+        if (my @results = $self->{repl}->reps($code)) {
+            $result = $results[-1];
+            $self->send_response( { value => $result } );
+        }
+        1;
     } or do {
         my $error = $@;
         $self->send_response( { err => $error } );


### PR DESCRIPTION
This streams any side-effect output from the code being evaluated as `out` responses to the client. It seems to work in my testing. ~I haven't included `stderr` handling because I don't know how to send things to `stderr` in Lingy code.~ We also stream `err` responses for any `stderr` happening during evaluation, though I don't know how to test that.

Also, a tad unrelated: The op used to send back evaluation errors as result, but that leaves the client with no way to distinguish between errors and successful evaluations. So now we do what other nREPL servers do, send an `err` response and no result value.

I tried doing this in several ways before arriving at this. At first it seemed to work by rebinding stdout in a sub process, but I realized that then any modifications to the Lingy app being developed where lost between evaluations... Anyway, if you know better ways to do this, I'm eager to learn!