### PR TITLE
Pez/more complete eval result

### DIFF
--- a/perl/lib/Lingy/Printer.pm
+++ b/perl/lib/Lingy/Printer.pm
@@ -25,7 +25,7 @@ sub pr_str {
         $type = 'Lingy::KeySymbol';
     }
 
-    $type or return WWW $o, "Don't know how to print internal value '$o'";
+    $type or return WWW $o, "Don't know how to print non-Lingy-object value '$o'";
 
     $type eq ATOM ? "(atom ${\ $self->pr_str($o->[0], $raw)})" :
     $type eq STRING ? $raw ? $$o :

--- a/perl/lib/Lingy/nREPL.pm
+++ b/perl/lib/Lingy/nREPL.pm
@@ -58,7 +58,7 @@ sub op_eval {
     my ($self) = @_;
 
     if (my $file = $self->{request}{file}) {
-        RT->env->set('*file*', $file);
+        RT->env->set('*file*', STRING->new($file));
     }
 
     my $result;

--- a/perl/lib/Lingy/nREPL.pm
+++ b/perl/lib/Lingy/nREPL.pm
@@ -2,6 +2,7 @@ use strict; use warnings;
 package Lingy::nREPL;
 
 use Lingy;
+use Lingy::Common;
 use IO::Socket::INET;
 use IO::Select;
 use Bencode;
@@ -64,7 +65,7 @@ sub op_eval {
     };
     $result = $@ if $@;
 
-    $self->send_response({value => $result});
+    $self->send_response({value => $result, ns => RT->current_ns_name});
 
     $self->send_response({status => 'done'});
 }

--- a/perl/lib/Lingy/nREPL.pm
+++ b/perl/lib/Lingy/nREPL.pm
@@ -69,7 +69,10 @@ sub op_eval {
     };
     $result = $@ if $@;
 
-    $self->send_response({value => $result, ns => RT->current_ns_name});
+    $self->send_response({
+        value => $result,
+        ns => RT->current_ns_name
+    });
 
     $self->send_response({status => 'done'});
 }

--- a/perl/lib/Lingy/nREPL.pm
+++ b/perl/lib/Lingy/nREPL.pm
@@ -57,6 +57,10 @@ sub new {
 sub op_eval {
     my ($self) = @_;
 
+    if (my $file = $self->{request}{file}) {
+        RT->env->set('*file*', $file);
+    }
+
     my $result;
     eval {
         my $code = $self->{request}{code};


### PR DESCRIPTION
* Adding `ns` to the value response. So if the evaluation changes current namespace, the client is informed about it.
* The `eval` op has an optional `file` that is supposed to set `clojure.core/*file*`, so made our `eval` op honor that.

For some reason I get an error back when evaluating `*file*`:

```
Don't know how to print internal value '/Users/pez/Projects/lingy-nrepl/bottles.ly'
```

Indicating that we are setting it correctly, but just lack some default as_string() thing when it is returned as a result.